### PR TITLE
fixing non-determenistic op ordering reported as issue #20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+.vscode
+.venv

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 Tensorflow port of Yoon Kim's [Torch7 code](https://github.com/yoonkim/lstm-char-cnn). See also similar project [here](https://github.com/carpedm20/lstm-char-cnn-tensorflow) that failed to reproduce Kim's results and was apparently abandoned by the author. Many pieces of code are borrowed from it.
 
 ## Installation
-You need tensorflow version 1.0 and python (obviously).
+You need tensorflow and python (obviously). The recommended way is to use virtual environment:
+```sh
+virtualenv .venv -p python3
+. .venv/bin/activate
+pip install tensorflow
+```
 
 ## Running
 


### PR DESCRIPTION
@mkudinov please review.

This is somewhat theoretical fix.

1. removed initial cleanup of padding in char embedding matrix from train.py. This should not affect training as each training step will be clearing it anyway
2. used `tf.control_dependencies` to schedule embedding cleanup just after gradients were applied (in `train.py`)

Please, confirm it is working correctly now.
